### PR TITLE
assets prefix issue at Rails 4.2

### DIFF
--- a/app/views/erd/erd/_model.html.erb
+++ b/app/views/erd/erd/_model.html.erb
@@ -1,5 +1,5 @@
 <div id="erd-<%= model[:model] %>" class="model" style="top: <%= model[:y] %>px; left: <%= model[:x] %>px;" data-model_name="<%= model[:model] %>">
-  <a href="#!" class="close"><%= image_tag("/assets/erd/close.png") %></a>
+  <a href="#!" class="close"><%= image_tag("erd/close.png") %></a>
   <div class="model_name">
     <div class="model_name_text"><%= model[:model] %></div>
     <form class="rename_model_form">

--- a/app/views/erd/erd/index.html.erb
+++ b/app/views/erd/erd/index.html.erb
@@ -2,9 +2,9 @@
   <div id="erd_container">
     <%=raw @erd %>
   </div>
-  <div id="open_migration"><%= image_tag("/assets/erd/angle-left.png") %></div>
+  <div id="open_migration"><%= image_tag("erd/angle-left.png") %></div>
   <div id="migration">
-    <div id="close_migration"><%= image_tag("/assets/erd/angle-right.png") %></div>
+    <div id="close_migration"><%= image_tag("erd/angle-right.png") %></div>
     <%- if flash[:executed_migrations].present? -%>
       <div id="executed">
         <h2>Successfully executed following <%= flash[:executed_migrations].values.flatten.count %> migrations!</h2>


### PR DESCRIPTION
## About this PR

fix issue #16 

## Test

I confirm that this fix version work with my sample Rails application which is uploaded at [My GitHub repository](https://github.com/h5y1m141/todo_rails).

### My Ruby/Rails environment 

- OS
  - Mac OS X 10.11.5
- Ruby
  - 2.2.2
- Rails
  - 4.2.0

### Test result

Add assets path precompile at config/initializers/assets.rb as following

```ruby
Rails.application.config.assets.precompile += %w( erd/* )
```

access http://localhost:3000/erd and show ER diagram as follows 

![2016-05-27 8 20 42](https://cloud.githubusercontent.com/assets/950924/15593067/f240f966-23e3-11e6-873a-bbd8c94f3010.png)