### PR TITLE
schema_migrations_table_name has been removed in AR 5.2

### DIFF
--- a/lib/erd/migrator.rb
+++ b/lib/erd/migrator.rb
@@ -6,7 +6,8 @@ module Erd
   class Migrator
     class << self
       def status
-        migrated_versions = ActiveRecord::Base.connection.select_values("SELECT version FROM #{ActiveRecord::Migrator.schema_migrations_table_name}").map {|v| '%.3d' % v}
+        table_name = Rails.version.to_f > 5.0 ? ActiveRecord::SchemaMigration.table_name : ActiveRecord::Migrator.schema_migrations_table_name
+        migrated_versions = ActiveRecord::Base.connection.select_values("SELECT version FROM #{table_name}").map {|v| '%.3d' % v}
         migrations = []
         ActiveRecord::Migrator.migrations_paths.each do |path|
           Dir.foreach(Rails.root.join(path)) do |file|

--- a/test/fake_app/db/migrate/20120428022519_create_authors.rb
+++ b/test/fake_app/db/migrate/20120428022519_create_authors.rb
@@ -1,4 +1,4 @@
-class CreateAuthors < ActiveRecord::Migration
+class CreateAuthors < ActiveRecord::VERSION::MAJOR >= 5 ? ActiveRecord::Migration[4.2] : ActiveRecord::Migration
   def change
     create_table :authors do |t|
       t.string :name

--- a/test/fake_app/db/migrate/20120428022535_create_books.rb
+++ b/test/fake_app/db/migrate/20120428022535_create_books.rb
@@ -1,4 +1,4 @@
-class CreateBooks < ActiveRecord::Migration
+class CreateBooks < ActiveRecord::VERSION::MAJOR >= 5 ? ActiveRecord::Migration[4.2] : ActiveRecord::Migration
   def change
     create_table :books do |t|
       t.references :author


### PR DESCRIPTION
ActiveRecord::Migrator.schema_migrations_table_name has been removed in AR 5.2