### PR TITLE
Show only 10 schema changes rows

### DIFF
--- a/app/assets/javascripts/erd/erd.js.js
+++ b/app/assets/javascripts/erd/erd.js.js
@@ -52,6 +52,11 @@ class ERD {
       $(existing[3]).text(from);
       $(existing[4]).text(to);
     }
+    $('#changes > tbody > tr').each(function(i, tr) {
+      const visible = $('#changes > tbody > tr:visible');
+      if (visible.length <= 10) { return; }
+      $(tr).hide();
+    });
     $('#changes').show();
   }
 


### PR DESCRIPTION
When I move DB table graph, schema changes table in sidebar is inserted a lot of rows.
And the table makes me lots of scroll.

So, I reduce visible rows.

Before
https://i.gyazo.com/a12c62aeb3309793f7833289b1231d7e.gif

After
https://i.gyazo.com/9cd3a282084665c25777e166d3823a26.gif
