### PR TITLE
Prepend the root route instead of appending it

### DIFF
--- a/lib/erd/railtie.rb
+++ b/lib/erd/railtie.rb
@@ -11,7 +11,7 @@ module Erd
     initializer 'erd' do
       ActiveSupport.on_load(:after_initialize) do
         if Rails.env.development?
-          Rails.application.routes.append do
+          Rails.application.routes.prepend do
             mount Erd::Engine, :at => '/erd'
           end
         end


### PR DESCRIPTION
By prepending the `/erd` route instead of appending it we can simply give this route the highest priority.
That way it won't get overridden by other, more generic route definitions.

fix #25