### PR TITLE
Fix mistaken args of map function

### DIFF
--- a/app/assets/javascripts/erd/erd.js.js
+++ b/app/assets/javascripts/erd/erd.js.js
@@ -395,7 +395,7 @@ $(function() {
         const model = $('#new_model_name').val();
         let columns = '';
         $('#create_model_table > tbody > tr').each(function(i, row) {
-          const [name, type] = $(row).find('input').map((v) => $(v).val());
+          const [name, type] = $(row).find('input').map((_, v)=> $(v).val());
           if (name) { columns += `${name}${type ? `:${type}` : ''} `; }
         });
         window.erd.upsert_change('create_model', model, columns, '', '');


### PR DESCRIPTION
## Description
There is no reaction when pushing `Create Model` button.
`erd.js.js` has mistaken args of map function, so I fix it.

## Before
[![Image from Gyazo](https://i.gyazo.com/3e18664eab5455033efb57dc6634a350.gif)](https://gyazo.com/3e18664eab5455033efb57dc6634a350)

## After
[![Image from Gyazo](https://i.gyazo.com/3e6a108314b711a1464f07b32567a3bc.gif)](https://gyazo.com/3e6a108314b711a1464f07b32567a3bc)