### PR TITLE
compact zeitwerk loader

### DIFF
--- a/app/controllers/erd/erd_controller.rb
+++ b/app/controllers/erd/erd_controller.rb
@@ -2,7 +2,6 @@
 
 require 'nokogiri'
 require 'ruby-graphviz'
-require 'erd/application_controller'
 
 module Erd
   class ErdController < ::Erd::ApplicationController


### PR DESCRIPTION
Since app/controlers is a normal Rails Engine dir, don't need to require 'erd/application_controller' manually. BUT zeitwerk will raise error if require from here.