### PR TITLE
Follow breaking changes to get SchemaMigration DB table name on Rails 7.1+

### DIFF
--- a/lib/erd/migrator.rb
+++ b/lib/erd/migrator.rb
@@ -9,7 +9,7 @@ module Erd
     class << self
       def status
         migrations = []
-        migration_table_name = defined?(ActiveRecord::SchemaMigration) ? ActiveRecord::SchemaMigration.table_name : ActiveRecord::Migrator.schema_migrations_table_name
+        migration_table_name = find_schema_migration_table_name
         return migrations unless ActiveRecord::Base.connection.table_exists? migration_table_name
 
         migrated_versions = ActiveRecord::Base.connection.select_values("SELECT version FROM #{migration_table_name}").map {|v| '%.3d' % v}
@@ -48,6 +48,15 @@ module Erd
           end
         end
         #TODO unload migraion classes
+      end
+
+      private
+
+      def find_schema_migration_table_name
+        return ActiveRecord::Migrator.schema_migrations_table_name unless defined?(ActiveRecord::SchemaMigration)
+        return ActiveRecord::SchemaMigration.table_name if ActiveRecord::SchemaMigration.respond_to?(:table_name)
+
+        ActiveRecord::Base.connection.schema_migration.table_name
       end
     end
   end


### PR DESCRIPTION
Fixes error when click on "Edit Database" on Rails 7.1+.
This is the new way to get the SchemaMigration table name:

```
ActiveRecord::Base.connection.schema_migration.table_name
```

See more at: https://github.com/rails/rails/pull/45908 and the final changelog at https://github.com/rails/rails/releases/tag/v7.1.0

> Move ActiveRecord::InternalMetadata to an independent object.
> 
> ActiveRecord::InternalMetadata no longer inherits from ActiveRecord::Base and is now an independent object that should be instantiated with a connection. This class is private and should not be used by applications directly. If you want to interact with the schema migrations table, please access it on the connection directly, for example: ActiveRecord::Base.connection.schema_migration.
> 
> Eileen M. Uchitelle